### PR TITLE
Move stats panel into enemy section

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,32 +13,6 @@
     <div class="game">
         <header class="game__header">
             <h1>샬레 전술 훈련</h1>
-            <div class="game__stats">
-                <div class="stat">
-                    <span class="stat__label">스테이지</span>
-                    <span id="stage" class="stat__value">1</span>
-                </div>
-                <div class="stat">
-                    <span class="stat__label">골드</span>
-                    <span id="gold" class="stat__value">0</span>
-                </div>
-                <div class="stat">
-                    <span class="stat__label">강화 재료</span>
-                    <span id="upgradeMaterials" class="stat__value">0</span>
-                </div>
-                <div class="stat">
-                    <span class="stat__label">모집권</span>
-                    <span id="gachaTokensHeader" class="stat__value">0</span>
-                </div>
-                <div class="stat">
-                    <span class="stat__label">전술 공격력</span>
-                    <span id="clickDamage" class="stat__value">1</span>
-                </div>
-                <div class="stat">
-                    <span class="stat__label">총 지원 화력</span>
-                    <span id="totalDps" class="stat__value">0</span>
-                </div>
-            </div>
         </header>
 
         <main class="game__main">
@@ -61,6 +35,34 @@
                 <div id="bossControls" class="boss-controls">
                     <button id="bossRetreat" class="btn btn-ghost boss-control__button" type="button">보스 퇴각</button>
                     <button id="bossAdvance" class="btn btn-secondary boss-control__button" type="button">보스 돌입</button>
+                </div>
+                <div class="game__enemy-stats">
+                    <div class="game__stats">
+                        <div class="stat">
+                            <span class="stat__label">스테이지</span>
+                            <span id="stage" class="stat__value">1</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">골드</span>
+                            <span id="gold" class="stat__value">0</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">강화 재료</span>
+                            <span id="upgradeMaterials" class="stat__value">0</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">모집권</span>
+                            <span id="gachaTokensHeader" class="stat__value">0</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">전술 공격력</span>
+                            <span id="clickDamage" class="stat__value">1</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">총 지원 화력</span>
+                            <span id="totalDps" class="stat__value">0</span>
+                        </div>
+                    </div>
                 </div>
                 <div class="game__progress">
                     <div class="progress-track" id="stageProgressTrack"></div>

--- a/styles.css
+++ b/styles.css
@@ -48,10 +48,11 @@ h1,
 
 .game__header {
     display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
 }
 
 .game__header h1 {
@@ -65,6 +66,17 @@ h1,
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 1rem;
+    width: 100%;
+    justify-items: center;
+}
+
+.game__enemy-stats {
+    width: 100%;
+}
+
+.game__enemy-stats .game__stats {
+    margin: 0 auto;
+    max-width: 100%;
 }
 
 .stat {


### PR DESCRIPTION
## Summary
- move the statistics grid out of the header and into the enemy encounter panel beneath the controls
- center the simplified header and ensure the relocated stats grid spans the enemy panel width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca2e5054508331a55794667aa87f5b