### PR TITLE
Split recruit panel from hero tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,18 @@
                     <button
                         type="button"
                         class="panel-tab"
+                        id="tab-recruit"
+                        role="tab"
+                        aria-selected="false"
+                        aria-controls="panel-recruit"
+                        data-tab-target="recruit"
+                        tabindex="-1"
+                    >
+                        학생 모집
+                    </button>
+                    <button
+                        type="button"
+                        class="panel-tab"
                         id="tab-rebirth"
                         role="tab"
                         aria-selected="false"
@@ -145,6 +157,43 @@
                                 <h2>학생</h2>
                                 <button id="sortHeroes" class="btn btn-secondary">정렬 순서 변경</button>
                             </header>
+                            <ul id="heroList" class="hero-list"></ul>
+                        </section>
+
+                        <section class="panel panel--upgrades">
+                            <header class="panel__header">
+                                <h2>샬레 지원 센터</h2>
+                            </header>
+                            <div class="upgrade">
+                                <div>
+                                    <h3>전술 교육 프로그램</h3>
+                                    <p>학생의 기본 공격력을 강화합니다.</p>
+                                </div>
+                                <button id="upgradeClick" class="btn btn-upgrade">전술 교육 (10 골드)</button>
+                            </div>
+                            <div class="upgrade">
+                                <div>
+                                    <h3>아로나의 전술 지원</h3>
+                                    <p>샬레의 지원 네트워크로 잠시 총 지원 화력을 2배로 높입니다.</p>
+                                </div>
+                                <button id="skillFrenzy" class="btn btn-skill">지원 요청 (쿨타임 60초)</button>
+                                <p id="skillCooldown" class="cooldown"></p>
+                            </div>
+                        </section>
+                    </div>
+
+                    <div
+                        class="panel-view"
+                        id="panel-recruit"
+                        role="tabpanel"
+                        aria-labelledby="tab-recruit"
+                        data-tab="recruit"
+                        hidden
+                    >
+                        <section class="panel panel--recruit" aria-label="학생 모집">
+                            <header class="panel__header">
+                                <h2>학생 모집</h2>
+                            </header>
                             <section class="gacha-panel" aria-label="학생 모집">
                                 <div class="gacha-panel__header">
                                     <div>
@@ -177,28 +226,6 @@
                                 ></ul>
                                 <p id="gachaResultsEmpty" class="gacha-results__empty">아직 모집 기록이 없습니다.</p>
                             </section>
-                            <ul id="heroList" class="hero-list"></ul>
-                        </section>
-
-                        <section class="panel panel--upgrades">
-                            <header class="panel__header">
-                                <h2>샬레 지원 센터</h2>
-                            </header>
-                            <div class="upgrade">
-                                <div>
-                                    <h3>전술 교육 프로그램</h3>
-                                    <p>학생의 기본 공격력을 강화합니다.</p>
-                                </div>
-                                <button id="upgradeClick" class="btn btn-upgrade">전술 교육 (10 골드)</button>
-                            </div>
-                            <div class="upgrade">
-                                <div>
-                                    <h3>아로나의 전술 지원</h3>
-                                    <p>샬레의 지원 네트워크로 잠시 총 지원 화력을 2배로 높입니다.</p>
-                                </div>
-                                <button id="skillFrenzy" class="btn btn-skill">지원 요청 (쿨타임 60초)</button>
-                                <p id="skillCooldown" class="cooldown"></p>
-                            </div>
                         </section>
                     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -361,6 +361,12 @@ h1,
     gap: 1.25rem;
 }
 
+.panel--recruit {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
 .panel--rebirth {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add a dedicated Recruit tab to the sidebar navigation
- move the existing gacha markup into the new Recruit panel while keeping hero management in its original tab
- style the Recruit panel to match spacing and layout of the other panels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca2f4a0af4833183ecf842c98405ad