### PR TITLE
Rebalance click upgrade ROI and rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
                                     <p>학생의 기본 공격력을 강화합니다.</p>
                                 </div>
                                 <button id="upgradeClick" class="btn btn-upgrade">전술 교육 (10 골드)</button>
+                                <p id="clickUpgradeInfo" class="upgrade__info" aria-live="polite"></p>
                             </div>
                             <div class="upgrade">
                                 <div>

--- a/styles.css
+++ b/styles.css
@@ -1726,10 +1726,19 @@ body.modal-open {
 
 .upgrade {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+}
+
+.upgrade__info {
+    flex: 1 1 100%;
+    font-size: 0.9rem;
+    color: var(--subtext-color);
+    margin-top: 0.25rem;
+    line-height: 1.4;
 }
 
 .cooldown {


### PR DESCRIPTION
## Summary
- add reusable balance helpers for click upgrade costs, damage scaling, and stage rewards
- recalculate click upgrade ROI to show expected payback and gold gains in the UI
- refresh the upgrade panel layout to display the new ROI message cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca4809dc988331ae1a498a3e7f3d14