### PR TITLE
Add dedicated mobile layout and panel selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,23 @@
             </section>
 
             <aside class="game__panel">
+                <div class="mobile-panel-control">
+                    <span class="mobile-panel-control__label" id="mobilePanelLabel">패널 선택</span>
+                    <div class="mobile-panel-control__field">
+                        <select
+                            id="mobilePanelSelect"
+                            class="mobile-panel-control__select"
+                            aria-labelledby="mobilePanelLabel"
+                        >
+                            <option value="heroes" selected>학생</option>
+                            <option value="recruit">학생 모집</option>
+                            <option value="rebirth">환생</option>
+                            <option value="equipment">전술 장비</option>
+                            <option value="missions">임무</option>
+                            <option value="log">전투 로그</option>
+                        </select>
+                    </div>
+                </div>
                 <nav class="panel-tabs" role="tablist" aria-label="보조 패널">
                     <button
                         type="button"

--- a/script.js
+++ b/script.js
@@ -1794,6 +1794,7 @@ const UI = {
     salvageModalCancel: document.getElementById('salvageModalCancel'),
     panelTabButtons: document.querySelectorAll('[data-tab-target]'),
     panelViews: document.querySelectorAll('[data-tab]'),
+    mobilePanelSelect: document.getElementById('mobilePanelSelect'),
 };
 
 class GameUI {
@@ -1810,6 +1811,7 @@ class GameUI {
         this.sortState = state.sortOrder === 'dps' ? 'dps' : 'level';
         this.tabButtons = [];
         this.tabPanels = new Map();
+        this.mobilePanelSelect = UI.mobilePanelSelect ?? null;
         this.setupTabs();
         this.setupEvents();
         this.updateGachaHistoryVisibility();
@@ -1839,6 +1841,14 @@ class GameUI {
                 }
             });
         });
+        if (this.mobilePanelSelect) {
+            this.mobilePanelSelect.addEventListener('change', (event) => {
+                const target = event.target.value;
+                if (target) {
+                    this.activateTab(target);
+                }
+            });
+        }
         const initialButton = this.tabButtons.find((button) => button.classList.contains('is-active'));
         const initialTab = initialButton?.dataset.tabTarget ?? this.tabButtons[0]?.dataset.tabTarget;
         if (initialTab) {
@@ -1867,6 +1877,9 @@ class GameUI {
             }
         });
         this.activeTab = tabId;
+        if (this.mobilePanelSelect && this.mobilePanelSelect.value !== tabId) {
+            this.mobilePanelSelect.value = tabId;
+        }
     }
 
     setupEvents() {

--- a/styles.css
+++ b/styles.css
@@ -288,6 +288,58 @@ h1,
     backdrop-filter: blur(10px);
 }
 
+.mobile-panel-control {
+    display: none;
+    align-items: center;
+    gap: 0.75rem;
+    background: rgba(15, 23, 42, 0.6);
+    padding: 0.85rem 1rem;
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(10px);
+}
+
+.mobile-panel-control__label {
+    font-size: 0.95rem;
+    color: var(--subtext-color);
+    letter-spacing: 0.5px;
+}
+
+.mobile-panel-control__field {
+    position: relative;
+    flex: 1;
+}
+
+.mobile-panel-control__field::after {
+    content: '\25BC';
+    position: absolute;
+    top: 50%;
+    right: 0.85rem;
+    transform: translateY(-50%);
+    pointer-events: none;
+    color: var(--subtext-color);
+    font-size: 0.8rem;
+    opacity: 0.8;
+}
+
+.mobile-panel-control__select {
+    width: 100%;
+    appearance: none;
+    background: rgba(15, 23, 42, 0.92);
+    color: var(--text-color);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 14px;
+    padding: 0.65rem 2.5rem 0.65rem 0.9rem;
+    font-size: 1rem;
+    line-height: 1.4;
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.1);
+}
+
+.mobile-panel-control__select:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.65);
+    outline-offset: 3px;
+}
+
 .panel-tab {
     border: 1px solid rgba(148, 163, 184, 0.25);
     background: transparent;
@@ -1776,58 +1828,162 @@ body.modal-open {
     }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
     .game {
-        padding: 1.5rem 1rem 2.5rem;
+        padding: 1.75rem 1.1rem 2.5rem;
     }
 
     .game__header h1 {
-        font-size: 2.4rem;
+        font-size: 2.6rem;
     }
 
-    .game__panel {
-        flex-direction: row;
-        align-items: stretch;
-        gap: 1rem;
+    .game__main {
+        gap: 1.75rem;
     }
 
-    .stat__value {
-        font-size: 1.4rem;
+    .game__enemy {
+        padding: 1.85rem 1.5rem;
+        border-radius: 22px;
     }
 
     .enemy {
-        width: 210px;
-        height: 210px;
+        width: min(60vw, 260px);
+        height: min(60vw, 260px);
     }
 
-    .enemy__sprite {
-        width: 130px;
-        height: 130px;
+    .game__stats {
+        gap: 0.85rem;
     }
 
-    .btn-primary {
-        width: 180px;
+    .stat {
+        padding: 0.9rem 1rem;
     }
 
-    .panel-tabs {
-        flex: 0 0 130px;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        padding: 0.75rem 0.5rem;
-        max-height: 65vh;
-        overflow-y: auto;
+    .stat__value {
+        font-size: 1.35rem;
     }
 
-    .panel-tab {
-        font-size: 0.95rem;
-        padding: 0.6rem 0.75rem;
+    .panel {
+        padding: 1.5rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .game {
+        padding: 1.25rem 0.75rem 2rem;
+        gap: 1.25rem;
+    }
+
+    .game__header h1 {
+        font-size: 2.2rem;
+    }
+
+    .game__main {
+        gap: 1.25rem;
+    }
+
+    .game__enemy {
+        padding: 1.5rem 1.1rem;
+        border-radius: 20px;
+        align-items: stretch;
+        gap: 1.1rem;
+    }
+
+    .enemy__info {
+        order: 1;
         text-align: left;
     }
 
+    .game__enemy-stats {
+        order: 2;
+    }
+
+    .game__stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem;
+    }
+
+    .enemy {
+        order: 3;
+        width: min(72vw, 240px);
+        height: min(72vw, 240px);
+        margin: 0 auto 1rem;
+    }
+
+    .enemy__sprite {
+        width: 60%;
+        height: 60%;
+    }
+
+    #tapButton {
+        order: 4;
+        width: 100%;
+        font-size: 1.15rem;
+        padding: 1rem 1.25rem;
+    }
+
+    .boss-controls {
+        order: 5;
+        width: 100%;
+    }
+
+    .boss-control__button {
+        flex: 1 1 calc(50% - 0.5rem);
+        max-width: none;
+    }
+
+    .game__progress {
+        order: 6;
+    }
+
+    .mobile-panel-control {
+        display: flex;
+        position: sticky;
+        top: 0.5rem;
+        z-index: 10;
+    }
+
+    .panel-tabs {
+        display: none;
+    }
+
+    .game__panel {
+        gap: 1rem;
+    }
+
     .panel-views {
-        flex: 1;
-        min-width: 0;
+        background: none;
+        padding: 0;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    .panel-view {
+        gap: 1.25rem;
+    }
+
+    .panel {
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 18px;
+        padding: 1.1rem 1rem;
+        box-shadow: var(--shadow);
+    }
+
+    .panel + .panel {
+        margin-top: 1rem;
+    }
+
+    .hero {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: left;
+        gap: 0.9rem;
+    }
+
+    .hero__info,
+    .hero__status,
+    .hero__actions {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a mobile-only panel selector to make auxiliary tabs easier to reach on phones
- tune responsive styles for the battlefield view and panels to improve readability on small screens
- hook the new selector into the existing tab switching logic for consistent behavior

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca515c7dd48331906d444a5d42020b