### PR TITLE
Handle legacy media query listeners in GameUI

### DIFF
--- a/src/ui/gameUI.js
+++ b/src/ui/gameUI.js
@@ -167,10 +167,22 @@ export class GameUI {
                 : null;
         this.setupTabs();
         this.setupEvents();
+        this.removeMobileViewportListener = null;
         if (this.mobileViewport) {
-            this.mobileViewport.addEventListener('change', () => {
+            const viewportListener = () => {
                 this.handleViewportChange();
-            });
+            };
+            if (typeof this.mobileViewport.addEventListener === 'function') {
+                this.mobileViewport.addEventListener('change', viewportListener);
+                this.removeMobileViewportListener = () => {
+                    this.mobileViewport?.removeEventListener('change', viewportListener);
+                };
+            } else if (typeof this.mobileViewport.addListener === 'function') {
+                this.mobileViewport.addListener(viewportListener);
+                this.removeMobileViewportListener = () => {
+                    this.mobileViewport?.removeListener(viewportListener);
+                };
+            }
             this.handleViewportChange();
         } else {
             this.handleViewportChange();


### PR DESCRIPTION
## Summary
- feature-detect the media query listener API when wiring up GameUI
- fall back to MediaQueryList.addListener when addEventListener is unavailable
- keep the overlay state initialization on startup regardless of API support

## Testing
- not run (manual browser verification required but not possible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca9ffacfac8331a5392bc4f4e1763b