### PR TITLE
Fix undefined HERO_RARITIES and MISSIONS references

### DIFF
--- a/src/state/gameState.js
+++ b/src/state/gameState.js
@@ -1788,6 +1788,7 @@ export {
     HERO_TRAIT_GROUP_MAP,
     HERO_TRAIT_MAP,
     HERO_RARITY_MAP,
+    HERO_RARITIES,
     DEFAULT_HERO_RARITY_ID,
     EQUIPMENT_EFFECT_MAP,
     EQUIPMENT_TYPE_MAP,
@@ -1822,4 +1823,5 @@ export {
     randomInt,
     weightedRandom,
     chooseRarity,
+    MISSIONS,
 };

--- a/src/ui/gameUI.js
+++ b/src/ui/gameUI.js
@@ -12,10 +12,11 @@ import {
     EQUIPMENT_RARITY_MAP,
     HERO_TRAIT_GROUP_MAP,
     HERO_TRAIT_MAP,
+    HERO_RARITIES,
+    MISSIONS,
     clampProbability,
 } from '../state/gameState.js';
-import { HERO_SET_BONUSES, HERO_RARITIES } from '../data/heroes.js';
-import { MISSIONS } from '../data/missions.js';
+import { HERO_SET_BONUSES } from '../data/heroes.js';
 import { EQUIPMENT_TYPES, EQUIPMENT_DROP_CHANCE, EQUIPMENT_BOSS_DROP_CHANCE } from '../data/equipment.js';
 import { REBIRTH_EFFECT_LABELS, REBIRTH_SKILLS } from '../data/rebirth.js';
 import { saveGame } from '../storage/save.js';


### PR DESCRIPTION
## Summary
- re-export HERO_RARITIES and MISSIONS from the shared game state module so UI imports no longer depend on separate globals
- update the UI module to import these datasets from the game state alongside its other shared constants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caa3edd6bc833185cb1bb35152957d