### PR TITLE
feat: redesign panel overlay for desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,8 @@
                         type="button"
                         id="panelOverlayClose"
                         class="panel-overlay__close"
+                        aria-hidden="true"
+                        tabindex="-1"
                         aria-label="보조 패널 닫기"
                     >
                         닫기 ✕

--- a/src/ui/gameUI.js
+++ b/src/ui/gameUI.js
@@ -163,32 +163,9 @@ export class GameUI {
         this.panelOverlay = UI.panelOverlay ?? null;
         this.panelOverlayBackdrop = UI.panelOverlayBackdrop ?? null;
         this.panelOverlayClose = UI.panelOverlayClose ?? null;
-        this.mobileViewport =
-            typeof window !== 'undefined' && 'matchMedia' in window
-                ? window.matchMedia('(max-width: 768px)')
-                : null;
         this.setupTabs();
         this.setupEvents();
-        this.removeMobileViewportListener = null;
-        if (this.mobileViewport) {
-            const viewportListener = () => {
-                this.handleViewportChange();
-            };
-            if (typeof this.mobileViewport.addEventListener === 'function') {
-                this.mobileViewport.addEventListener('change', viewportListener);
-                this.removeMobileViewportListener = () => {
-                    this.mobileViewport?.removeEventListener('change', viewportListener);
-                };
-            } else if (typeof this.mobileViewport.addListener === 'function') {
-                this.mobileViewport.addListener(viewportListener);
-                this.removeMobileViewportListener = () => {
-                    this.mobileViewport?.removeListener(viewportListener);
-                };
-            }
-            this.handleViewportChange();
-        } else {
-            this.handleViewportChange();
-        }
+        this.handleViewportChange();
         this.updateGachaHistoryVisibility();
         this.renderGachaOverview();
         this.renderHeroSetBonuses();
@@ -214,9 +191,7 @@ export class GameUI {
                 const target = button.dataset.tabTarget;
                 if (target) {
                     this.activateTab(target);
-                    if (this.isMobileViewport()) {
-                        this.openPanelOverlay();
-                    }
+                    this.openPanelOverlay();
                 }
             });
         });
@@ -251,24 +226,11 @@ export class GameUI {
         this.updateOverlayAriaState();
     }
 
-    isMobileViewport() {
-        if (this.mobileViewport) {
-            return this.mobileViewport.matches;
-        }
-        if (typeof window !== 'undefined') {
-            return window.innerWidth <= 768;
-        }
-        return false;
-    }
-
     isPanelOverlayOpen() {
         return this.panelOverlay?.classList.contains('is-overlay-open') ?? false;
     }
 
     openPanelOverlay() {
-        if (!this.isMobileViewport()) {
-            return;
-        }
         if (this.panelOverlay) {
             this.panelOverlay.classList.add('is-overlay-open');
         }
@@ -285,31 +247,17 @@ export class GameUI {
     }
 
     updateOverlayAriaState() {
-        const isMobile = this.isMobileViewport();
         const isOpen = this.isPanelOverlayOpen();
         this.tabButtons.forEach((button) => {
-            if (isMobile) {
-                const isActive = button.dataset.tabTarget === this.activeTab;
-                button.setAttribute('aria-expanded', isOpen && isActive ? 'true' : 'false');
-            } else {
-                button.removeAttribute('aria-expanded');
-            }
+            const isActive = button.dataset.tabTarget === this.activeTab;
+            button.setAttribute('aria-expanded', isOpen && isActive ? 'true' : 'false');
         });
         if (this.panelOverlayBackdrop) {
-            if (isMobile) {
-                this.panelOverlayBackdrop.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-            } else {
-                this.panelOverlayBackdrop.setAttribute('aria-hidden', 'true');
-            }
+            this.panelOverlayBackdrop.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
         }
         if (this.panelOverlayClose) {
-            if (isMobile) {
-                this.panelOverlayClose.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
-                this.panelOverlayClose.setAttribute('tabindex', isOpen ? '0' : '-1');
-            } else {
-                this.panelOverlayClose.setAttribute('aria-hidden', 'true');
-                this.panelOverlayClose.setAttribute('tabindex', '-1');
-            }
+            this.panelOverlayClose.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+            this.panelOverlayClose.setAttribute('tabindex', isOpen ? '0' : '-1');
         }
     }
 
@@ -1668,7 +1616,7 @@ export class GameUI {
             this.closeSalvageModal();
             return;
         }
-        if (this.isMobileViewport() && this.isPanelOverlayOpen()) {
+        if (this.isPanelOverlayOpen()) {
             event.preventDefault();
             this.closePanelOverlay();
         }

--- a/styles.css
+++ b/styles.css
@@ -34,9 +34,14 @@ body {
     color: var(--text-color);
     min-height: 100vh;
     height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: stretch;
+    display: block;
+    margin: 0;
+    padding-bottom: 8rem;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+body.is-panel-overlay-open {
     overflow: hidden;
 }
 
@@ -49,12 +54,12 @@ h1,
 .game {
     width: min(1200px, 100%);
     margin: 0 auto;
-    padding: 1.25rem 1.75rem 1.75rem;
-    display: grid;
-    grid-template-rows: auto 1fr auto;
-    gap: 1.25rem;
-    height: 100vh;
-    height: 100dvh;
+    padding: 1.75rem 2.25rem 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    min-height: 100dvh;
+    position: relative;
 }
 
 .game__header {
@@ -111,11 +116,11 @@ h1,
 }
 
 .game__main {
-    display: grid;
-    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
-    gap: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
     min-height: 0;
-    align-items: stretch;
+    align-items: center;
 }
 
 .game__enemy {
@@ -127,7 +132,9 @@ h1,
     grid-template-rows: auto minmax(0, 1fr) auto auto auto auto;
     align-items: center;
     gap: 0.9rem;
-    height: 100%;
+    width: min(100%, 860px);
+    margin: 0 auto;
+    height: auto;
     min-height: 0;
     overflow-y: auto;
     scrollbar-gutter: stable both-edges;
@@ -310,39 +317,64 @@ h1,
 }
 
 .game__panel {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    background: var(--panel-color);
-    border-radius: 24px;
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    height: 100%;
-    min-height: 0;
     position: relative;
-    overflow: hidden;
+    display: block;
+    height: 0;
+    min-height: 0;
+    overflow: visible;
+}
+
+.panel-overlay__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+    z-index: 40;
+}
+
+.game__panel.is-overlay-open .panel-overlay__backdrop {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .panel-tabs {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    display: flex;
+    align-items: center;
     gap: 0.75rem;
-    background: rgba(15, 23, 42, 0.7);
-    padding: 0.75rem;
-    border-radius: 18px;
-    box-shadow: var(--shadow);
-    backdrop-filter: blur(10px);
-    position: sticky;
-    top: 0;
-    z-index: 10;
+    position: fixed;
+    left: 50%;
+    bottom: 1.5rem;
+    transform: translateX(-50%);
+    width: min(960px, calc(100% - 3rem));
+    padding: 0.75rem 1rem;
+    border-radius: 22px;
+    background: rgba(15, 23, 42, 0.9);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(14px);
+    pointer-events: auto;
+    z-index: 48;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+}
+
+.panel-tabs::-webkit-scrollbar {
+    display: none;
 }
 
 .panel-tab {
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    flex: 0 0 auto;
+    white-space: nowrap;
+    border: 1px solid rgba(148, 163, 184, 0.3);
     background: transparent;
     color: var(--subtext-color);
-    padding: 0.65rem 0.9rem;
-    border-radius: 14px;
+    padding: 0.65rem 1.1rem;
+    border-radius: 16px;
     font-size: 1rem;
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
@@ -351,7 +383,7 @@ h1,
 
 .panel-tab:hover {
     color: #e2e8f0;
-    border-color: rgba(148, 163, 184, 0.45);
+    border-color: rgba(148, 163, 184, 0.5);
 }
 
 .panel-tab:focus-visible {
@@ -363,7 +395,7 @@ h1,
     background: linear-gradient(120deg, rgba(56, 189, 248, 0.92), rgba(14, 165, 233, 0.9));
     color: #0f172a;
     border-color: rgba(255, 255, 255, 0.35);
-    box-shadow: 0 14px 30px rgba(56, 189, 248, 0.35);
+    box-shadow: 0 14px 32px rgba(56, 189, 248, 0.35);
     transform: translateY(-1px);
 }
 
@@ -372,39 +404,55 @@ h1,
 }
 
 .panel-views {
-    position: relative;
-    flex: 1;
-    min-height: 0;
+    position: fixed;
+    left: 50%;
+    bottom: 0;
+    width: min(960px, calc(100% - 2.5rem));
+    max-height: min(75vh, 760px);
+    padding: 3.25rem 2.25rem 2.5rem;
+    background: rgba(15, 23, 42, 0.98);
+    border-radius: 32px 32px 0 0;
+    box-shadow: 0 -24px 50px rgba(15, 23, 42, 0.6);
+    transform: translate(-50%, calc(100% + 2rem));
+    transition: transform 0.3s ease;
+    pointer-events: none;
+    z-index: 47;
     overflow-y: auto;
-    padding-right: 0.5rem;
-    padding-bottom: 0.5rem;
-    margin-right: -0.5rem;
+    overscroll-behavior-y: contain;
     scrollbar-gutter: stable both-edges;
+    backdrop-filter: blur(18px);
+}
+
+.game__panel.is-overlay-open .panel-views {
+    transform: translate(-50%, 0);
+    pointer-events: auto;
 }
 
 .panel-overlay__close {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
-    display: none;
+    top: 1.35rem;
+    right: 1.75rem;
+    display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    padding: 0.45rem 0.85rem;
+    gap: 0.4rem;
+    padding: 0.55rem 1.1rem;
     border-radius: 999px;
     border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(15, 23, 42, 0.7);
-    color: var(--subtext-color);
-    font-size: 0.9rem;
+    background: rgba(15, 23, 42, 0.75);
+    color: #f1f5f9;
+    font-size: 0.95rem;
     font-weight: 600;
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
         box-shadow 0.2s ease;
+    z-index: 49;
 }
 
 .panel-overlay__close:hover {
     color: #f8fafc;
     border-color: rgba(148, 163, 184, 0.55);
-    background: rgba(15, 23, 42, 0.85);
+    background: rgba(15, 23, 42, 0.88);
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.35);
 }
 
 .panel-overlay__close:focus-visible {
@@ -412,7 +460,7 @@ h1,
     outline-offset: 3px;
 }
 
-.panel-overlay__backdrop {
+.panel-overlay__close[aria-hidden='true'] {
     display: none;
 }
 
@@ -2008,77 +2056,6 @@ body.modal-open {
     text-align: right;
 }
 
-@media (max-width: 1024px) {
-    body {
-        display: block;
-        overflow: auto;
-    }
-
-    .game {
-        height: auto;
-        min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-        padding: 1.5rem 1.25rem 2.5rem;
-    }
-
-    .game__main {
-        grid-template-columns: 1fr;
-        gap: 1.75rem;
-    }
-
-    .game__panel {
-        order: -1;
-        background: transparent;
-        box-shadow: none;
-        padding: 0;
-        height: auto;
-        min-height: auto;
-    }
-
-    .panel-tabs {
-        position: static;
-    }
-
-    .panel-views {
-        flex: initial;
-        min-height: auto;
-        overflow: visible;
-        padding-right: 0;
-        margin-right: 0;
-        scrollbar-gutter: auto;
-    }
-
-    .game__enemy {
-        order: 1;
-        overflow: visible;
-        scrollbar-gutter: auto;
-    }
-
-    #tapButton {
-        max-width: none;
-    }
-
-    .game__stats {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .game__footer {
-        flex-direction: column;
-        align-items: center;
-        gap: 0.75rem;
-    }
-
-    .game__footer > div {
-        justify-content: center;
-    }
-
-    .game__footer-text {
-        text-align: center;
-    }
-}
-
 @media (max-width: 768px) {
     .game {
         padding: 1.75rem 1.1rem 2.5rem;
@@ -2191,87 +2168,26 @@ body.modal-open {
         padding-bottom: 6.5rem;
     }
 
-    body.is-panel-overlay-open {
-        overflow: hidden;
-    }
-
-    .game__panel {
-        display: block;
-        position: static;
-        height: 0;
-        margin: 0;
-        z-index: auto;
-    }
-
-    .panel-overlay__backdrop {
-        display: block;
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, 0.55);
-        opacity: 0;
-        visibility: hidden;
-        transition: opacity 0.25s ease;
-        pointer-events: none;
-        z-index: 40;
-    }
-
-    .game__panel.is-overlay-open .panel-overlay__backdrop {
-        opacity: 1;
-        visibility: visible;
-        pointer-events: auto;
-    }
-
     .panel-tabs {
-        display: flex;
-        align-items: center;
-        gap: 0.65rem;
-        position: fixed;
-        left: 50%;
-        bottom: 1.15rem;
-        transform: translateX(-50%);
-        width: min(520px, calc(100% - 2rem));
-        padding: 0.65rem 0.75rem;
-        border-radius: 20px;
-        background: rgba(15, 23, 42, 0.9);
-        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.55);
-        pointer-events: auto;
-        z-index: 48;
-        overflow-x: auto;
-        overscroll-behavior-x: contain;
-    }
-
-    .panel-tabs::-webkit-scrollbar {
-        display: none;
+        bottom: 1rem;
+        width: calc(100% - 1.5rem);
+        padding: 0.6rem 0.75rem;
+        border-radius: 18px;
+        gap: 0.6rem;
     }
 
     .panel-tab {
-        flex: 0 0 auto;
-        white-space: nowrap;
-        padding: 0.6rem 0.95rem;
+        padding: 0.55rem 0.9rem;
         font-size: 0.95rem;
     }
 
     .panel-views {
-        position: fixed;
-        left: 0;
-        right: 0;
-        bottom: 0;
+        width: calc(100% - 1.5rem);
         max-height: 74vh;
-        padding: 2.75rem 1.25rem 2.25rem;
-        background: rgba(15, 23, 42, 0.98);
-        border-radius: 26px 26px 0 0;
-        box-shadow: 0 -20px 40px rgba(15, 23, 42, 0.55);
-        transform: translateY(calc(100% + 1.5rem));
-        transition: transform 0.3s ease;
-        pointer-events: none;
-        z-index: 47;
-        overflow-y: auto;
-        overscroll-behavior-y: contain;
-    }
-
-    .game__panel.is-overlay-open .panel-views {
-        transform: translateY(0);
-        pointer-events: auto;
+        padding: 2.75rem 1.1rem 2rem;
+        border-radius: 24px 24px 0 0;
+        box-shadow: 0 -18px 38px rgba(15, 23, 42, 0.55);
+        transform: translate(-50%, calc(100% + 1.5rem));
     }
 
     .panel-view {
@@ -2279,7 +2195,7 @@ body.modal-open {
     }
 
     .panel {
-        background: rgba(15, 23, 42, 0.88);
+        background: rgba(15, 23, 42, 0.9);
         border-radius: 20px;
         padding: 1.25rem 1.1rem;
         box-shadow: var(--shadow);
@@ -2290,8 +2206,9 @@ body.modal-open {
     }
 
     .panel-overlay__close {
-        display: inline-flex;
-        z-index: 49;
+        top: 1.05rem;
+        right: 1.25rem;
+        padding: 0.5rem 0.95rem;
     }
 
     .hero {


### PR DESCRIPTION
## Summary
- restyle the desktop layout to center the main content and anchor the tab navigation/overlay to the bottom like the mobile design
- update overlay interactions so every viewport opens the bottom sheet and keeps aria attributes/backdrop in sync
- ensure the close button starts hidden until the overlay is toggled on

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa857dd9c833195dce451ed736ae5