### PR TITLE
Add hero critical upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,14 @@
                             <span id="totalDps" class="stat__value">0</span>
                         </div>
                         <div class="stat">
+                            <span class="stat__label">학생 치명타 확률</span>
+                            <span id="heroCritChance" class="stat__value">0%</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat__label">학생 치명타 배율</span>
+                            <span id="heroCritMultiplier" class="stat__value">0배</span>
+                        </div>
+                        <div class="stat">
                             <span class="stat__label">치명타 확률</span>
                             <span id="critChance" class="stat__value">0%</span>
                         </div>
@@ -102,6 +110,18 @@
                         tabindex="-1"
                     >
                         학생 모집
+                    </button>
+                    <button
+                        type="button"
+                        class="panel-tab"
+                        id="tab-skills"
+                        role="tab"
+                        aria-selected="false"
+                        aria-controls="panel-skills"
+                        data-tab-target="skills"
+                        tabindex="-1"
+                    >
+                        전술 스킬
                     </button>
                     <button
                         type="button"
@@ -217,6 +237,22 @@
                             </div>
                             <div class="upgrade">
                                 <div>
+                                    <h3>학생 정밀 사격 훈련</h3>
+                                    <p>지원 학생들의 치명타 확률을 향상시킵니다.</p>
+                                </div>
+                                <button id="upgradeHeroCritChance" class="btn btn-upgrade">학생 치명타 교정 (150 골드)</button>
+                                <p id="heroCritChanceUpgradeInfo" class="upgrade__info" aria-live="polite"></p>
+                            </div>
+                            <div class="upgrade">
+                                <div>
+                                    <h3>학생 탄두 개량 연구</h3>
+                                    <p>학생 치명타 발생 시 피해 배율을 높입니다.</p>
+                                </div>
+                                <button id="upgradeHeroCritDamage" class="btn btn-upgrade">학생 탄두 개량 (200 골드)</button>
+                                <p id="heroCritDamageUpgradeInfo" class="upgrade__info" aria-live="polite"></p>
+                            </div>
+                            <div class="upgrade">
+                                <div>
                                     <h3>지원 화력 지휘 과정</h3>
                                     <p>학생 전체의 DPS를 영구적으로 증가시킵니다.</p>
                                 </div>
@@ -230,14 +266,6 @@
                                 </div>
                                 <button id="upgradeGoldGain" class="btn btn-upgrade">자금 운용 훈련 (125 골드)</button>
                                 <p id="goldGainUpgradeInfo" class="upgrade__info" aria-live="polite"></p>
-                            </div>
-                            <div class="upgrade">
-                                <div>
-                                    <h3>아로나의 전술 지원</h3>
-                                    <p>샬레의 지원 네트워크로 잠시 총 지원 화력을 2배로 높입니다.</p>
-                                </div>
-                                <button id="skillFrenzy" class="btn btn-skill">지원 요청 (쿨타임 60초)</button>
-                                <p id="skillCooldown" class="cooldown"></p>
                             </div>
                         </section>
                     </div>
@@ -286,6 +314,29 @@
                                 ></ul>
                                 <p id="gachaResultsEmpty" class="gacha-results__empty">아직 모집 기록이 없습니다.</p>
                             </section>
+                        </section>
+                    </div>
+
+                    <div
+                        class="panel-view"
+                        id="panel-skills"
+                        role="tabpanel"
+                        aria-labelledby="tab-skills"
+                        data-tab="skills"
+                        hidden
+                    >
+                        <section class="panel panel--skills">
+                            <header class="panel__header">
+                                <h2>전술 스킬</h2>
+                            </header>
+                            <div class="upgrade">
+                                <div>
+                                    <h3>아로나의 전술 지원</h3>
+                                    <p>샬레의 지원 네트워크로 잠시 총 지원 화력을 2배로 높입니다.</p>
+                                </div>
+                                <button id="skillFrenzy" class="btn btn-skill">지원 요청 (쿨타임 60초)</button>
+                                <p id="skillCooldown" class="cooldown"></p>
+                            </div>
                         </section>
                     </div>
 


### PR DESCRIPTION
## Summary
- add student critical chance and multiplier stats to the HUD and support center upgrades
- extend game state with hero critical chance/multiplier progression and DPS calculations
- wire new UI controls and logs to manage the student critical upgrades
- separate the tactical skill controls into their own panel tab

## Testing
- no automated tests were run (project has no test suite)

------
https://chatgpt.com/codex/tasks/task_e_68cb4547c7908331ace50d5722768829