### PR TITLE
Display hero roster as icon grid with detail overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,12 +533,46 @@
         </div>
     </div>
 
-    <template id="heroTemplate">
-        <li class="hero" data-recruited="false" data-rarity="common">
+    <div id="heroDetailOverlay" class="hero-detail-overlay" aria-hidden="true">
+        <div id="heroDetailBackdrop" class="hero-detail-overlay__backdrop" data-dismiss="true"></div>
+        <div class="hero-detail-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="heroDetailTitle">
+            <button
+                type="button"
+                id="heroDetailClose"
+                class="hero-detail-overlay__close"
+                aria-label="학생 정보 닫기"
+            >
+                ✕
+            </button>
+            <div id="heroDetailContent" class="hero-detail-overlay__content"></div>
+        </div>
+    </div>
+
+    <template id="heroIconTemplate">
+        <li class="hero-icon" data-recruited="false" data-rarity="common">
+            <button type="button" class="hero-icon__button">
+                <span class="hero-icon__media" aria-hidden="true">
+                    <img
+                        class="hero-icon__image"
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        hidden
+                    />
+                    <span class="hero-icon__placeholder"></span>
+                    <span class="hero-icon__lock" aria-hidden="true">🔒</span>
+                </span>
+                <span class="hero-icon__name"></span>
+            </button>
+        </li>
+    </template>
+
+    <template id="heroDetailTemplate">
+        <article class="hero" data-recruited="false" data-rarity="common">
             <div class="hero__info">
                 <div class="hero__header">
                     <span class="hero__rarity"></span>
-                    <h3 class="hero__name"></h3>
+                    <h3 id="heroDetailTitle" class="hero__name"></h3>
                 </div>
                 <p class="hero__desc"></p>
                 <div class="hero__meta">
@@ -563,7 +597,7 @@
                 <span class="hero__status-state"></span>
                 <span class="hero__status-detail"></span>
             </div>
-        </li>
+        </article>
     </template>
 
     <script type="module" src="src/main.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -41,7 +41,8 @@ body {
     overflow-y: auto;
 }
 
-body.is-panel-overlay-open {
+body.is-panel-overlay-open,
+body.is-hero-detail-open {
     overflow: hidden;
 }
 
@@ -771,10 +772,181 @@ h1,
 
 .hero-list {
     list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+    gap: 0.85rem;
+    max-height: 340px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.hero-icon {
+    --hero-icon-accent: rgba(148, 163, 184, 0.35);
+    position: relative;
+}
+
+.hero-icon[data-recruited='true'] {
+    --hero-icon-accent: rgba(56, 189, 248, 0.45);
+}
+
+.hero-icon__button {
+    width: 100%;
+    border: none;
+    background: transparent;
+    cursor: pointer;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    max-height: 340px;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+}
+
+.hero-icon__button:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 4px;
+}
+
+.hero-icon__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 18px;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.75));
+    border: 2px solid var(--hero-icon-accent);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero-icon[data-recruited='false'] .hero-icon__media {
+    filter: grayscale(0.25);
+    opacity: 0.85;
+}
+
+.hero-icon__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.hero-icon__image[hidden] {
+    display: none;
+}
+
+.hero-icon__placeholder {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.75));
+}
+
+.hero-icon[data-has-image='true'] .hero-icon__placeholder {
+    display: none;
+}
+
+.hero-icon__lock {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    font-size: 1.15rem;
+    text-shadow: 0 0 10px rgba(15, 23, 42, 0.65);
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.hero-icon[data-recruited='false'] .hero-icon__lock {
+    opacity: 0.95;
+    transform: scale(1);
+}
+
+.hero-icon__name {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.hero-icon__button:hover .hero-icon__media {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.55);
+}
+
+.hero-detail-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 1000;
+}
+
+.hero-detail-overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.hero-detail-overlay__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.7);
+    backdrop-filter: blur(8px);
+}
+
+.hero-detail-overlay__dialog {
+    position: relative;
+    width: min(640px, 100%);
+    max-height: min(90vh, 720px);
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 24px;
+    padding: 1.75rem 1.75rem 1.5rem;
+    box-shadow: 0 30px 65px rgba(15, 23, 42, 0.55);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.hero-detail-overlay__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    border: none;
+    background: rgba(15, 23, 42, 0.8);
+    color: rgba(248, 250, 252, 0.9);
+    font-size: 1.25rem;
+    border-radius: 999px;
+    width: 2.25rem;
+    height: 2.25rem;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.45);
+}
+
+.hero-detail-overlay__close:hover {
+    background: rgba(30, 41, 59, 0.85);
+}
+
+.hero-detail-overlay__close:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 2px;
+}
+
+.hero-detail-overlay__content {
     overflow-y: auto;
     padding-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- replace the hero list markup with an icon template and add a modal overlay template for student details
- update the game UI logic to render hero icons, open the detail overlay with skin controls, and manage focus/escape handling
- add styling for the icon grid and overlay presentation while preventing background scroll when the detail view is open

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb4e82b19c8331add989399297db0c