### PR TITLE
Convert equipment inventory to icon grid with detail overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@
                                         </button>
                                     </div>
                                 </div>
-                                <ul id="equipmentInventory" class="equipment-list"></ul>
+                                <ul id="equipmentInventory" class="equipment-grid" aria-label="전술 장비 목록"></ul>
                                 <p id="equipmentEmpty" class="equipment-empty">아직 확보한 전술 장비가 없습니다.</p>
                             </div>
                         </section>
@@ -533,12 +533,46 @@
         </div>
     </div>
 
-    <template id="heroTemplate">
-        <li class="hero" data-recruited="false" data-rarity="common">
+    <div id="heroDetailOverlay" class="hero-detail-overlay" aria-hidden="true">
+        <div id="heroDetailBackdrop" class="hero-detail-overlay__backdrop" data-dismiss="true"></div>
+        <div class="hero-detail-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="heroDetailTitle">
+            <button
+                type="button"
+                id="heroDetailClose"
+                class="hero-detail-overlay__close"
+                aria-label="학생 정보 닫기"
+            >
+                ✕
+            </button>
+            <div id="heroDetailContent" class="hero-detail-overlay__content"></div>
+        </div>
+    </div>
+
+    <template id="heroIconTemplate">
+        <li class="hero-icon" data-recruited="false" data-rarity="common">
+            <button type="button" class="hero-icon__button">
+                <span class="hero-icon__media" aria-hidden="true">
+                    <img
+                        class="hero-icon__image"
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        hidden
+                    />
+                    <span class="hero-icon__placeholder"></span>
+                    <span class="hero-icon__lock" aria-hidden="true">🔒</span>
+                </span>
+                <span class="hero-icon__name"></span>
+            </button>
+        </li>
+    </template>
+
+    <template id="heroDetailTemplate">
+        <article class="hero" data-recruited="false" data-rarity="common">
             <div class="hero__info">
                 <div class="hero__header">
                     <span class="hero__rarity"></span>
-                    <h3 class="hero__name"></h3>
+                    <h3 id="heroDetailTitle" class="hero__name"></h3>
                 </div>
                 <p class="hero__desc"></p>
                 <div class="hero__meta">
@@ -563,7 +597,69 @@
                 <span class="hero__status-state"></span>
                 <span class="hero__status-detail"></span>
             </div>
+        </article>
+    </template>
+
+    <div id="equipmentDetailOverlay" class="equipment-detail-overlay" aria-hidden="true">
+        <div id="equipmentDetailBackdrop" class="equipment-detail-overlay__backdrop" data-dismiss="true"></div>
+        <div class="equipment-detail-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="equipmentDetailTitle">
+            <button
+                type="button"
+                id="equipmentDetailClose"
+                class="equipment-detail-overlay__close"
+                aria-label="전술 장비 정보 닫기"
+            >
+                ✕
+            </button>
+            <div id="equipmentDetailContent" class="equipment-detail-overlay__content"></div>
+        </div>
+    </div>
+
+    <template id="equipmentIconTemplate">
+        <li
+            class="equipment-icon"
+            data-equipment-id=""
+            data-rarity="common"
+            data-equipped="false"
+            data-salvageable="false"
+            data-selected="false"
+        >
+            <button type="button" class="equipment-icon__button" data-equipment-id="">
+                <span class="equipment-icon__media" aria-hidden="true">
+                    <span class="equipment-icon__type"></span>
+                    <span class="equipment-icon__level"></span>
+                </span>
+                <span class="equipment-icon__effect"></span>
+                <span class="equipment-icon__name"></span>
+            </button>
+            <label class="equipment-icon__select">
+                <input type="checkbox" data-select-id="" />
+                <span>선택</span>
+            </label>
         </li>
+    </template>
+
+    <template id="equipmentDetailTemplate">
+        <article class="equipment-detail" data-rarity="common" data-equipped="false" data-salvageable="false">
+            <header class="equipment-detail__header">
+                <span class="equipment-detail__rarity"></span>
+                <h3 id="equipmentDetailTitle" class="equipment-detail__name"></h3>
+            </header>
+            <div class="equipment-detail__meta">
+                <span class="equipment-detail__type"></span>
+                <span class="equipment-detail__level"></span>
+                <span class="equipment-detail__stage"></span>
+            </div>
+            <div class="equipment-detail__effects" role="list" aria-label="장비 효과"></div>
+            <p class="equipment-detail__status"></p>
+            <div class="equipment-detail__actions">
+                <button type="button" class="btn btn-ghost equipment-detail__lock" data-lock-id="">잠금</button>
+                <button type="button" class="btn btn-upgrade equipment-detail__upgrade" data-upgrade-id="">강화</button>
+                <button type="button" class="btn btn-secondary equipment-detail__equip" data-equip-id="">장착</button>
+                <button type="button" class="btn btn-danger equipment-detail__salvage" data-salvage-id="">분해</button>
+            </div>
+            <button type="button" class="btn btn-ghost equipment-detail__selection" data-select-id=""></button>
+        </article>
     </template>
 
     <script type="module" src="src/main.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,141 @@
     --rarity-legendary: #facc15;
 }
 
+.equipment-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.equipment-icon {
+    --equipment-icon-accent: rgba(148, 163, 184, 0.35);
+    position: relative;
+    background: rgba(30, 41, 59, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 18px;
+    padding: 0.85rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    min-height: 170px;
+    display: flex;
+}
+
+.equipment-icon__button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.55rem;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+}
+
+.equipment-icon__button:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 4px;
+}
+
+.equipment-icon__media {
+    width: 100%;
+    border: 2px solid var(--equipment-icon-accent);
+    border-radius: 14px;
+    padding: 0.65rem 0.75rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(15, 23, 42, 0.85));
+    min-height: 60px;
+}
+
+.equipment-icon__type,
+.equipment-icon__level {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.8);
+    color: rgba(226, 232, 240, 0.92);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.4);
+}
+
+.equipment-icon__effect {
+    font-size: 0.82rem;
+    color: rgba(148, 163, 184, 0.9);
+    min-height: 2.4em;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.equipment-icon__name {
+    font-size: 1.05rem;
+    line-height: 1.25;
+}
+
+.equipment-icon__select {
+    position: absolute;
+    top: 0.65rem;
+    right: 0.65rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    font-size: 0.68rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.equipment-icon__select input {
+    width: 0.9rem;
+    height: 0.9rem;
+}
+
+.equipment-icon__select input:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.equipment-icon:hover {
+    transform: translateY(-4px);
+    border-color: rgba(56, 189, 248, 0.35);
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.4);
+}
+
+.equipment-icon[data-equipped='true'] {
+    border-color: rgba(56, 189, 248, 0.55);
+    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.equipment-icon[data-selected='true'] {
+    box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.45);
+}
+
+.equipment-icon[data-salvageable='false'] .equipment-icon__select {
+    opacity: 0.65;
+}
+
+.equipment-empty {
+    font-size: 0.9rem;
+    color: rgba(148, 163, 184, 0.7);
+    text-align: center;
+}
+
 * {
     box-sizing: border-box;
     margin: 0;
@@ -41,7 +176,9 @@ body {
     overflow-y: auto;
 }
 
-body.is-panel-overlay-open {
+body.is-panel-overlay-open,
+body.is-hero-detail-open,
+body.is-equipment-detail-open {
     overflow: hidden;
 }
 
@@ -771,12 +908,362 @@ h1,
 
 .hero-list {
     list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+    gap: 0.85rem;
     max-height: 340px;
     overflow-y: auto;
     padding-right: 0.5rem;
+}
+
+.hero-icon {
+    --hero-icon-accent: rgba(148, 163, 184, 0.35);
+    position: relative;
+}
+
+.hero-icon[data-recruited='true'] {
+    --hero-icon-accent: rgba(56, 189, 248, 0.45);
+}
+
+.hero-icon__button {
+    width: 100%;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+}
+
+.hero-icon__button:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 4px;
+}
+
+.hero-icon__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 18px;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.75));
+    border: 2px solid var(--hero-icon-accent);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero-icon[data-recruited='false'] .hero-icon__media {
+    filter: grayscale(0.25);
+    opacity: 0.85;
+}
+
+.hero-icon__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.hero-icon__image[hidden] {
+    display: none;
+}
+
+.hero-icon__placeholder {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.75));
+}
+
+.hero-icon[data-has-image='true'] .hero-icon__placeholder {
+    display: none;
+}
+
+.hero-icon__lock {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    font-size: 1.15rem;
+    text-shadow: 0 0 10px rgba(15, 23, 42, 0.65);
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.hero-icon[data-recruited='false'] .hero-icon__lock {
+    opacity: 0.95;
+    transform: scale(1);
+}
+
+.hero-icon__name {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.hero-icon__button:hover .hero-icon__media {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.55);
+}
+
+.hero-detail-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 1000;
+}
+
+.hero-detail-overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.hero-detail-overlay__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.7);
+    backdrop-filter: blur(8px);
+}
+
+.hero-detail-overlay__dialog {
+    position: relative;
+    width: min(640px, 100%);
+    max-height: min(90vh, 720px);
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 24px;
+    padding: 1.75rem 1.75rem 1.5rem;
+    box-shadow: 0 30px 65px rgba(15, 23, 42, 0.55);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.hero-detail-overlay__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    border: none;
+    background: rgba(15, 23, 42, 0.8);
+    color: rgba(248, 250, 252, 0.9);
+    font-size: 1.25rem;
+    border-radius: 999px;
+    width: 2.25rem;
+    height: 2.25rem;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.45);
+}
+
+.hero-detail-overlay__close:hover {
+    background: rgba(30, 41, 59, 0.85);
+}
+
+.hero-detail-overlay__close:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 2px;
+}
+
+.hero-detail-overlay__content {
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.equipment-detail-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 1100;
+}
+
+.equipment-detail-overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.equipment-detail-overlay__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.7);
+    backdrop-filter: blur(8px);
+}
+
+.equipment-detail-overlay__dialog {
+    position: relative;
+    width: min(560px, 100%);
+    max-height: min(90vh, 680px);
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 24px;
+    padding: 1.6rem 1.6rem 1.4rem;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.55);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.equipment-detail-overlay__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    border: none;
+    background: rgba(15, 23, 42, 0.8);
+    color: rgba(248, 250, 252, 0.9);
+    font-size: 1.2rem;
+    border-radius: 999px;
+    width: 2.2rem;
+    height: 2.2rem;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.45);
+}
+
+.equipment-detail-overlay__close:hover {
+    background: rgba(30, 41, 59, 0.85);
+}
+
+.equipment-detail-overlay__close:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.75);
+    outline-offset: 2px;
+}
+
+.equipment-detail-overlay__content {
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.equipment-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    --equipment-detail-accent: rgba(148, 163, 184, 0.8);
+}
+
+.equipment-detail[data-rarity='uncommon'] {
+    --equipment-detail-accent: rgba(34, 211, 238, 0.85);
+}
+
+.equipment-detail[data-rarity='rare'] {
+    --equipment-detail-accent: rgba(168, 85, 247, 0.85);
+}
+
+.equipment-detail[data-rarity='unique'] {
+    --equipment-detail-accent: rgba(249, 115, 22, 0.85);
+}
+
+.equipment-detail[data-rarity='legendary'] {
+    --equipment-detail-accent: rgba(250, 204, 21, 0.95);
+}
+
+.equipment-detail__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.equipment-detail__rarity {
+    font-size: 0.8rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--equipment-detail-accent);
+}
+
+.equipment-detail__name {
+    font-size: clamp(1.4rem, 2vw, 1.8rem);
+    line-height: 1.2;
+}
+
+.equipment-detail__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    color: rgba(148, 163, 184, 0.9);
+}
+
+.equipment-detail__meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+}
+
+.equipment-detail__effects {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    margin-top: 0.5rem;
+}
+
+.equipment-detail__effect {
+    background: rgba(56, 189, 248, 0.12);
+    border: 1px solid rgba(56, 189, 248, 0.25);
+    border-radius: 12px;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.95);
+}
+
+.equipment-detail[data-rarity='rare'] .equipment-detail__effect {
+    background: rgba(168, 85, 247, 0.12);
+    border-color: rgba(168, 85, 247, 0.35);
+}
+
+.equipment-detail[data-rarity='unique'] .equipment-detail__effect {
+    background: rgba(249, 115, 22, 0.12);
+    border-color: rgba(249, 115, 22, 0.35);
+}
+
+.equipment-detail[data-rarity='legendary'] .equipment-detail__effect {
+    background: rgba(250, 204, 21, 0.15);
+    border-color: rgba(250, 204, 21, 0.45);
+}
+
+.equipment-detail__status {
+    font-size: 0.9rem;
+    color: rgba(148, 163, 184, 0.85);
+}
+
+.equipment-detail__actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+}
+
+.equipment-detail__selection {
+    align-self: flex-start;
+    margin-top: 0.35rem;
 }
 
 .gacha-panel {
@@ -1659,147 +2146,42 @@ h1,
     color: rgba(148, 163, 184, 0.7);
 }
 
-.equipment-list {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    max-height: 200px;
-    overflow-y: auto;
-    padding-right: 0.5rem;
-}
-
-.equipment-item {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 1rem;
-    background: rgba(30, 41, 59, 0.9);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 16px;
-    padding: 0.85rem 1.1rem;
-    transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
-}
-
-.equipment-item:hover {
-    transform: translateY(-3px);
-}
-
-.equipment-item__info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    flex: 1;
-}
-
-.equipment-item__select {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    color: rgba(148, 163, 184, 0.75);
-}
-
-.equipment-item__select input {
-    width: 1.1rem;
-    height: 1.1rem;
-    cursor: pointer;
-}
-
-.equipment-item__select input:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-}
-
-.equipment-item__select-label {
-    font-size: 0.7rem;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-}
-
-.equipment-item__status {
-    font-size: 0.85rem;
-    color: rgba(148, 163, 184, 0.8);
-}
-
-.equipment-item__status[data-state='available'] {
-    color: var(--success-color);
-}
-
-.equipment-item__status[data-state='locked'] {
-    color: var(--danger-color);
-}
-
-.equipment-item__status[data-state='equipped'] {
-    color: var(--accent-color);
-}
-
-.equipment-item__name {
-    font-size: 1.05rem;
-}
-
-.equipment-item__details {
-    font-size: 0.9rem;
-    color: var(--subtext-color);
-}
-
-.equipment-item__actions {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.5rem;
-}
-
-.equipment-item__equip.btn,
-.equipment-item__upgrade.btn,
-.equipment-item__lock.btn,
-.equipment-item__salvage.btn {
-    min-width: 115px;
-    padding: 0.6rem 1.2rem;
-}
-
-.equipment-item[data-equipped='true'] {
-    border-color: rgba(56, 189, 248, 0.65);
-    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
-}
 
 .equipment-slot[data-equipped='false'] {
     opacity: 0.85;
 }
 
-.equipment-empty {
-    font-size: 0.9rem;
-    color: rgba(148, 163, 184, 0.7);
-    text-align: center;
-}
-
-.equipment-item[data-rarity='common'],
+.equipment-icon[data-rarity='common'],
 .equipment-slot[data-rarity='common'] {
     border-color: rgba(148, 163, 184, 0.35);
+    --equipment-icon-accent: rgba(148, 163, 184, 0.35);
 }
 
-.equipment-item[data-rarity='uncommon'],
+.equipment-icon[data-rarity='uncommon'],
 .equipment-slot[data-rarity='uncommon'] {
     border-color: rgba(34, 211, 238, 0.45);
+    --equipment-icon-accent: rgba(34, 211, 238, 0.55);
 }
 
-.equipment-item[data-rarity='rare'],
+.equipment-icon[data-rarity='rare'],
 .equipment-slot[data-rarity='rare'] {
     border-color: rgba(168, 85, 247, 0.55);
+    --equipment-icon-accent: rgba(168, 85, 247, 0.55);
 }
 
-.equipment-item[data-rarity='unique'],
+.equipment-icon[data-rarity='unique'],
 .equipment-slot[data-rarity='unique'] {
     border-color: rgba(249, 115, 22, 0.55);
+    --equipment-icon-accent: rgba(249, 115, 22, 0.6);
 }
 
-.equipment-item[data-rarity='legendary'],
+.equipment-icon[data-rarity='legendary'],
 .equipment-slot[data-rarity='legendary'] {
     border-color: rgba(250, 204, 21, 0.7);
+    --equipment-icon-accent: rgba(250, 204, 21, 0.7);
 }
 
-.equipment-item[data-rarity='legendary'] .equipment-item__name,
+.equipment-icon[data-rarity='legendary'] .equipment-icon__name,
 .equipment-slot[data-rarity='legendary'] .equipment-slot__name {
     color: #fde68a;
 }


### PR DESCRIPTION
## Summary
- replace the equipment inventory list with an icon-based layout and new DOM templates
- add an equipment detail overlay with locking, upgrading, equipping, salvage, and selection controls
- overhaul equipment styles to support the icon grid, overlay presentation, and selection feedback

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb4e82b19c8331add989399297db0c