### PR TITLE
Adjust overlay heights for dvh support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -465,6 +465,12 @@ h1,
     backdrop-filter: blur(18px);
 }
 
+@supports (height: 100dvh) {
+    .panel-views {
+        max-height: min(clamp(0px, 75dvh, 75vh), 760px);
+    }
+}
+
 .game__panel.is-overlay-open .panel-views {
     transform: translate(-50%, 0);
     pointer-events: auto;
@@ -1205,6 +1211,16 @@ h1,
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
+}
+
+@supports (height: 100dvh) {
+    .hero-detail-overlay__dialog {
+        max-height: min(clamp(0px, 90dvh, 90vh), 720px);
+    }
+
+    .equipment-detail-overlay__dialog {
+        max-height: min(clamp(0px, 90dvh, 90vh), 620px);
+    }
 }
 
 .equipment-detail-overlay__close {
@@ -2849,6 +2865,12 @@ body.modal-open {
         border-radius: 24px 24px 0 0;
         box-shadow: 0 -18px 38px rgba(15, 23, 42, 0.55);
         transform: translate(-50%, calc(100% + 1.5rem));
+    }
+
+    @supports (height: 100dvh) {
+        .panel-views {
+            max-height: clamp(0px, 74dvh, 74vh);
+        }
     }
 
     .panel-view {


### PR DESCRIPTION
## Summary
- add dynamic viewport height support for the bottom panel overlay while preserving legacy vh fallbacks
- update hero and equipment overlay dialogs to respect dvh with clamp-based safety bounds
- ensure mobile overlay layout also adapts to browsers supporting dynamic viewport units

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb6d98ca3883319bac99a2fd0cc821