### PR TITLE
Adjust overview layout for mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,14 @@ h1,
     z-index: 6;
 }
 
+@media (max-width: 640px) {
+    .game__overview {
+        position: static;
+        top: auto;
+        z-index: auto;
+    }
+}
+
 .overview-bar {
     background: rgba(15, 23, 42, 0.95);
     border-radius: 24px;


### PR DESCRIPTION
## Summary
- ensure the overview bar scrolls with the page on small screens by overriding its position in a mobile media query

## Testing
- manually verified the mobile layout in a 375px viewport

------
https://chatgpt.com/codex/tasks/task_e_68cb858d3dbc833182ce6b48ce6ffb11