### PR TITLE
Add mission reset scheduling and grouped UI

### DIFF
--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -1,50 +1,100 @@
-export const MISSIONS = [
+const DAY = 24 * 60 * 60 * 1000;
+const WEEK = 7 * DAY;
+
+const BASE_MISSION_GROUPS = [
     {
-        id: 'defeat_50',
-        name: '전술 훈련 I',
-        description: '적 50명을 처치하세요.',
-        trigger: 'enemyDefeat',
-        goal: 50,
-        reward: { type: 'gold', amount: 500 },
+        id: 'static',
+        label: '상시 임무',
+        description: '언제든 진행 가능한 기본 임무입니다.',
+        resetInterval: null,
+        slotLimit: null,
+        missions: [
+            {
+                id: 'defeat_50',
+                name: '전술 훈련 I',
+                description: '적 50명을 처치하세요.',
+                trigger: 'enemyDefeat',
+                goal: 50,
+                reward: { type: 'gold', amount: 500 },
+            },
+            {
+                id: 'defeat_250',
+                name: '전술 훈련 II',
+                description: '적 250명을 처치하세요.',
+                trigger: 'enemyDefeat',
+                goal: 250,
+                reward: { type: 'gachaTokens', amount: 3 },
+            },
+        ],
     },
     {
-        id: 'defeat_250',
-        name: '전술 훈련 II',
-        description: '적 250명을 처치하세요.',
-        trigger: 'enemyDefeat',
-        goal: 250,
-        reward: { type: 'gachaTokens', amount: 3 },
+        id: 'daily',
+        label: '일일 임무',
+        description: '매일 새로운 보상을 받을 수 있는 임무입니다.',
+        resetInterval: DAY,
+        slotLimit: 4,
+        missions: [
+            {
+                id: 'gacha_30',
+                name: '모집 전문가',
+                description: '학생 모집을 30회 진행하세요.',
+                trigger: 'gachaRoll',
+                goal: 30,
+                reward: { type: 'gold', amount: 1200 },
+            },
+            {
+                id: 'salvage_20',
+                name: '장비 정리 I',
+                description: '전술 장비를 20회 분해하세요.',
+                trigger: 'equipmentSalvage',
+                goal: 20,
+                reward: { type: 'gold', amount: 800 },
+            },
+        ],
     },
     {
-        id: 'gacha_30',
-        name: '모집 전문가',
-        description: '학생 모집을 30회 진행하세요.',
-        trigger: 'gachaRoll',
-        goal: 30,
-        reward: { type: 'gold', amount: 1200 },
-    },
-    {
-        id: 'salvage_20',
-        name: '장비 정리 I',
-        description: '전술 장비를 20회 분해하세요.',
-        trigger: 'equipmentSalvage',
-        goal: 20,
-        reward: { type: 'gold', amount: 800 },
-    },
-    {
-        id: 'salvage_100',
-        name: '장비 정리 II',
-        description: '전술 장비를 100회 분해하세요.',
-        trigger: 'equipmentSalvage',
-        goal: 100,
-        reward: { type: 'gachaTokens', amount: 4 },
-    },
-    {
-        id: 'rebirth_1',
-        name: '새로운 출발',
-        description: '환생을 1회 진행하세요.',
-        trigger: 'rebirth',
-        goal: 1,
-        reward: { type: 'gachaTokens', amount: 5 },
+        id: 'weekly',
+        label: '주간 임무',
+        description: '한 주 동안 꾸준히 진행하면 좋은 임무입니다.',
+        resetInterval: WEEK,
+        slotLimit: 4,
+        missions: [
+            {
+                id: 'salvage_100',
+                name: '장비 정리 II',
+                description: '전술 장비를 100회 분해하세요.',
+                trigger: 'equipmentSalvage',
+                goal: 100,
+                reward: { type: 'gachaTokens', amount: 4 },
+            },
+            {
+                id: 'rebirth_1',
+                name: '새로운 출발',
+                description: '환생을 1회 진행하세요.',
+                trigger: 'rebirth',
+                goal: 1,
+                reward: { type: 'gachaTokens', amount: 5 },
+            },
+        ],
     },
 ];
+
+export const MISSION_GROUPS = BASE_MISSION_GROUPS.map(({ missions, ...group }) => ({ ...group }));
+
+export const MISSION_GROUP_LOOKUP = MISSION_GROUPS.reduce((acc, group) => {
+    acc[group.id] = group;
+    return acc;
+}, {});
+
+export const MISSION_TYPE_ORDER = MISSION_GROUPS.map((group) => group.id);
+
+export const MISSIONS = BASE_MISSION_GROUPS.flatMap((group) =>
+    group.missions.map((mission) => ({
+        ...mission,
+        type: group.id,
+        resetInterval:
+            Number.isFinite(mission.resetInterval) && mission.resetInterval > 0
+                ? Math.floor(mission.resetInterval)
+                : group.resetInterval,
+    })),
+);

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,3 +1,23 @@
+const COUNTDOWN_UNIT_LABELS = {
+    ko: { day: '일', hour: '시간', minute: '분', second: '초', zero: '0초' },
+    en: { day: 'd', hour: 'h', minute: 'm', second: 's', zero: '0s' },
+    ja: { day: '日', hour: '時間', minute: '分', second: '秒', zero: '0秒' },
+};
+
+const resolveCountdownLabels = (locale) => {
+    if (!locale) return COUNTDOWN_UNIT_LABELS.ko;
+    const key = locale.toLowerCase().split('-')[0];
+    return COUNTDOWN_UNIT_LABELS[key] ?? COUNTDOWN_UNIT_LABELS.ko;
+};
+
+const resolveLocale = (locale) => {
+    if (locale) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+        return navigator.language;
+    }
+    return 'ko-KR';
+};
+
 export const formatNumber = (value) => {
     if (value >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
     if (value >= 1e6) return `${(value / 1e6).toFixed(2)}M`;
@@ -14,4 +34,48 @@ export const formatSignedPercent = (value) => {
     const normalized = Number.isFinite(value) ? value : 0;
     const sign = normalized >= 0 ? '+' : '-';
     return `${sign}${formatPercent(Math.abs(normalized))}`;
+};
+
+export const formatCountdown = (targetTime, now = Date.now(), options = {}) => {
+    const { maxUnits = 3, locale: preferredLocale } = options;
+    const locale = resolveLocale(preferredLocale);
+    const labels = resolveCountdownLabels(locale);
+    const target = Number(targetTime);
+    const current = Number(now);
+    if (!Number.isFinite(target) || !Number.isFinite(current)) {
+        return labels.zero;
+    }
+    const remainingMs = Math.max(0, target - current);
+    if (remainingMs <= 0) {
+        return labels.zero;
+    }
+    const totalSeconds = Math.floor(remainingMs / 1000);
+    const units = [
+        { unit: 'day', size: 86400 },
+        { unit: 'hour', size: 3600 },
+        { unit: 'minute', size: 60 },
+        { unit: 'second', size: 1 },
+    ];
+    const formatter = new Intl.NumberFormat(locale);
+    const segments = [];
+    let remainingSeconds = totalSeconds;
+    for (const { unit, size } of units) {
+        if (segments.length >= maxUnits) break;
+        if (unit !== 'second' && remainingSeconds < size && segments.length === 0) {
+            continue;
+        }
+        const value = Math.floor(remainingSeconds / size);
+        if (value <= 0) {
+            if (unit === 'second' && segments.length === 0) {
+                segments.push(`${formatter.format(0)}${labels[unit]}`);
+            }
+            continue;
+        }
+        segments.push(`${formatter.format(value)}${labels[unit]}`);
+        remainingSeconds -= value * size;
+    }
+    if (segments.length === 0) {
+        return labels.zero;
+    }
+    return segments.join(' ');
 };


### PR DESCRIPTION
## Summary
- reorganize mission data into typed groups with reset intervals and exportable metadata
- add mission reset bookkeeping, persistence, and grouped UI with countdowns, logs, and audio cues
- provide reusable countdown formatter for localized reset timers

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb8ad5ca3c8331aaa540e276b295c6