### PR TITLE
Integrate hero bond progression system

### DIFF
--- a/index.html
+++ b/index.html
@@ -635,6 +635,12 @@
                     <span class="hero-icon__placeholder"></span>
                     <span class="hero-icon__lock" aria-hidden="true">🔒</span>
                 </span>
+                <span class="hero-icon__bond" aria-hidden="true">
+                    <span class="hero-icon__bond-bar">
+                        <span class="hero-icon__bond-fill"></span>
+                    </span>
+                    <span class="hero-icon__bond-label">호감도 Lv.0</span>
+                </span>
                 <span class="hero-icon__name"></span>
             </button>
         </li>
@@ -652,6 +658,26 @@
                     <span class="hero__level"></span>
                     <span class="hero__dps"></span>
                 </div>
+                <section class="hero__bond" aria-label="호감도 현황">
+                    <div class="hero__bond-header">
+                        <span class="hero__bond-title">호감도</span>
+                        <span class="hero__bond-level"></span>
+                    </div>
+                    <div class="hero__bond-progress">
+                        <div class="hero__bond-bar">
+                            <div class="hero__bond-fill"></div>
+                        </div>
+                        <span class="hero__bond-value"></span>
+                    </div>
+                    <p class="hero__bond-next"></p>
+                    <button
+                        type="button"
+                        class="btn btn-secondary hero__bond-button"
+                        data-hero-bond-action="levelup"
+                    >
+                        호감도 레벨 업
+                    </button>
+                </section>
                 <div class="hero__traits" role="list" aria-label="학생 특성"></div>
                 <div class="hero__appearance">
                     <div class="hero__skin-preview" data-locked="true" aria-hidden="true">

--- a/src/data/heroes.js
+++ b/src/data/heroes.js
@@ -145,6 +145,175 @@ export const HERO_SKIN_LIBRARY = {
     ],
 };
 
+export const HERO_BOND_EXP_REQUIREMENTS = [0, 60, 140, 260, 420, 620];
+
+export const HERO_BOND_MAX_LEVEL = HERO_BOND_EXP_REQUIREMENTS.length - 1;
+
+export const HERO_BOND_REWARDS = {
+    shiroko: [
+        {
+            level: 1,
+            description: '시로코와의 자전거 순찰 덕분에 개인 화력이 10% 증가합니다.',
+            effects: { heroSelf: 0.1 },
+        },
+        {
+            level: 2,
+            description: '아비도스 대책위원회가 단결해 전체 학생 지원 화력이 3% 상승합니다.',
+            effects: { hero: 0.03 },
+        },
+        {
+            level: 3,
+            description: '정밀 사격 연습으로 학생 치명타 확률이 1% 증가합니다.',
+            effects: { heroCritChance: 0.01 },
+        },
+        {
+            level: 4,
+            description: '기동 타격 경험으로 전술 스킬 효율이 4% 상승합니다.',
+            effects: { skill: 0.04 },
+        },
+        {
+            level: 5,
+            description: '시로코의 절대 신뢰! 개인 화력이 추가로 15% 증가합니다.',
+            effects: { heroSelf: 0.15 },
+        },
+    ],
+    hoshino: [
+        {
+            level: 1,
+            description: '호시노의 든든한 응원으로 개인 방어 화력이 8% 상승합니다.',
+            effects: { heroSelf: 0.08 },
+        },
+        {
+            level: 2,
+            description: '대책위원회 보급이 강화되어 골드 획득량이 4% 증가합니다.',
+            effects: { gold: 0.04 },
+        },
+        {
+            level: 3,
+            description: '적응 훈련으로 학생 치명타 피해 배율이 6% 증가합니다.',
+            effects: { heroCritDamage: 0.06 },
+        },
+        {
+            level: 4,
+            description: '야전 침착함으로 장비 드롭률이 3% 상승합니다.',
+            effects: { equipmentDrop: 0.03 },
+        },
+        {
+            level: 5,
+            description: '호시노의 절대 충성! 개인 화력이 18% 상승합니다.',
+            effects: { heroSelf: 0.18 },
+        },
+    ],
+    aru: [
+        {
+            level: 1,
+            description: '아루의 계약으로 개인 화력이 12% 증가합니다.',
+            effects: { heroSelf: 0.12 },
+        },
+        {
+            level: 2,
+            description: '게헨나 지원을 받아 전술 스킬 효율이 5% 상승합니다.',
+            effects: { skill: 0.05 },
+        },
+        {
+            level: 3,
+            description: '치밀한 작전으로 전체 학생 지원 화력이 4% 증가합니다.',
+            effects: { hero: 0.04 },
+        },
+        {
+            level: 4,
+            description: '비밀 거래로 모집권 드롭률이 3% 상승합니다.',
+            effects: { gachaDrop: 0.03 },
+        },
+        {
+            level: 5,
+            description: '아루의 깊은 신뢰! 개인 화력이 추가로 15% 증가합니다.',
+            effects: { heroSelf: 0.15 },
+        },
+    ],
+    hibiki: [
+        {
+            level: 1,
+            description: '히비키의 화력 조정으로 개인 화력이 9% 증가합니다.',
+            effects: { heroSelf: 0.09 },
+        },
+        {
+            level: 2,
+            description: '포격 교정 데이터로 학생 치명타 확률이 1.2% 상승합니다.',
+            effects: { heroCritChance: 0.012 },
+        },
+        {
+            level: 3,
+            description: '분석력 향상으로 전술 스킬 효율이 6% 증가합니다.',
+            effects: { skill: 0.06 },
+        },
+        {
+            level: 4,
+            description: '밀레니엄 공방의 도움으로 장비 드롭률이 4% 상승합니다.',
+            effects: { equipmentDrop: 0.04 },
+        },
+        {
+            level: 5,
+            description: '히비키의 완벽 지원! 개인 화력이 16% 증가합니다.',
+            effects: { heroSelf: 0.16 },
+        },
+    ],
+    iroha: [
+        {
+            level: 1,
+            description: '이로하의 지휘로 개인 화력이 11% 증가합니다.',
+            effects: { heroSelf: 0.11 },
+        },
+        {
+            level: 2,
+            description: '전술 시뮬레이션 덕에 전체 학생 지원 화력이 3% 상승합니다.',
+            effects: { hero: 0.03 },
+        },
+        {
+            level: 3,
+            description: '지휘 통제로 전술 스킬 효율이 5% 증가합니다.',
+            effects: { skill: 0.05 },
+        },
+        {
+            level: 4,
+            description: '밀레니엄 데이터 공유로 학생 치명타 피해가 5% 증가합니다.',
+            effects: { heroCritDamage: 0.05 },
+        },
+        {
+            level: 5,
+            description: '완벽한 지휘 신뢰! 개인 화력이 17% 증가합니다.',
+            effects: { heroSelf: 0.17 },
+        },
+    ],
+    yuuka: [
+        {
+            level: 1,
+            description: '유우카의 철저한 계획으로 개인 화력이 9% 증가합니다.',
+            effects: { heroSelf: 0.09 },
+        },
+        {
+            level: 2,
+            description: '재무 관리로 골드 획득량이 5% 상승합니다.',
+            effects: { gold: 0.05 },
+        },
+        {
+            level: 3,
+            description: '통계 분석 덕분에 학생 치명타 확률이 1.5% 증가합니다.',
+            effects: { heroCritChance: 0.015 },
+        },
+        {
+            level: 4,
+            description: '정비 예산 확보로 장비 드롭률이 3% 상승합니다.',
+            effects: { equipmentDrop: 0.03 },
+        },
+        {
+            level: 5,
+            description: '유우카의 확신 어린 신뢰! 개인 화력이 16% 증가합니다.',
+            effects: { heroSelf: 0.16 },
+        },
+    ],
+};
+
 export const HERO_TRAIT_GROUPS = [
     {
         id: 'school',

--- a/styles.css
+++ b/styles.css
@@ -1106,6 +1106,43 @@ h1,
     box-shadow: 0 18px 32px rgba(15, 23, 42, 0.55);
 }
 
+.hero-icon__bond {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.25rem;
+}
+
+.hero-icon__bond-bar {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.28);
+    overflow: hidden;
+}
+
+.hero-icon__bond-fill {
+    position: absolute;
+    inset: 0;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.75));
+    transition: width 0.25s ease;
+}
+
+.hero-icon[data-recruited='false'] .hero-icon__bond-fill {
+    background: linear-gradient(90deg, rgba(148, 163, 184, 0.7), rgba(148, 163, 184, 0.45));
+}
+
+.hero-icon__bond-label {
+    font-size: 0.7rem;
+    color: rgba(226, 232, 240, 0.85);
+    letter-spacing: 0.02em;
+    text-align: center;
+}
+
 .hero-detail-overlay {
     position: fixed;
     inset: 0;
@@ -1573,6 +1610,11 @@ h1,
     color: rgba(148, 163, 184, 0.9);
 }
 
+.gacha-result__bond {
+    font-size: 0.8rem;
+    color: rgba(96, 165, 250, 0.95);
+}
+
 .gacha-result__skins {
     margin-top: 0.4rem;
     padding-top: 0.4rem;
@@ -1687,6 +1729,90 @@ h1,
     gap: 0.75rem;
     font-size: 0.95rem;
     color: rgba(226, 232, 240, 0.9);
+}
+
+.hero__bond {
+    margin-top: 0.35rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(56, 189, 248, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+}
+
+.hero__bond[data-state='locked'] {
+    opacity: 0.65;
+}
+
+.hero__bond-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.hero__bond-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.9);
+}
+
+.hero__bond-level {
+    font-weight: 600;
+    color: rgba(248, 250, 252, 0.95);
+}
+
+.hero__bond-progress {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.hero__bond-bar {
+    position: relative;
+    flex: 1;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(51, 65, 85, 0.8);
+    overflow: hidden;
+}
+
+.hero__bond-fill {
+    position: absolute;
+    inset: 0;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.75));
+    transition: width 0.3s ease;
+}
+
+.hero__bond-value {
+    min-width: 96px;
+    text-align: right;
+    font-size: 0.85rem;
+    color: rgba(226, 232, 240, 0.9);
+    font-variant-numeric: tabular-nums;
+}
+
+.hero__bond-next {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.9);
+    min-height: 1.2rem;
+}
+
+.hero__bond-button {
+    align-self: flex-end;
+    min-width: 160px;
+}
+
+.hero__bond-button[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .hero__traits {


### PR DESCRIPTION
## Summary
- persist bond level/experience on each hero and award progress from stages, missions, and gacha results while folding bond bonuses into hero/stat calculations
- add shared bond experience requirements and reward tables for key heroes
- expose bond gauges, progress details, and level-up controls in the hero UI with updated gacha history entries and styles

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb8f250c2c83319fd5740a835e2a65