### PR TITLE
Add modular skill system with UI integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,16 +296,12 @@
                                 <h2>전술 스킬</h2>
                             </header>
                             <div class="panel__body panel-card__body">
-                                <article class="skill-card">
-                                    <div class="skill-card__content">
-                                        <h3 class="skill-card__title">아로나의 전술 지원</h3>
-                                        <p class="skill-card__desc">샬레의 지원 네트워크로 잠시 총 지원 화력을 2배로 높입니다.</p>
-                                    </div>
-                                    <div class="skill-card__actions">
-                                        <button id="skillFrenzy" class="btn btn-skill">지원 요청 (쿨타임 60초)</button>
-                                        <p id="skillCooldown" class="cooldown"></p>
-                                    </div>
-                                </article>
+                                <ul
+                                    id="skillList"
+                                    class="skill-list"
+                                    aria-live="polite"
+                                    aria-label="사용 가능한 전술 스킬"
+                                ></ul>
                             </div>
                         </section>
 
@@ -620,6 +616,30 @@
             <div id="equipmentDetailContent" class="equipment-detail-overlay__content"></div>
         </div>
     </div>
+
+    <template id="skillTemplate">
+        <li class="skill-card" data-skill-id="">
+            <div class="skill-card__content">
+                <h3 class="skill-card__title"></h3>
+                <p class="skill-card__desc"></p>
+                <div class="skill-card__meta">
+                    <span class="skill-card__cooldown-hint"></span>
+                    <span class="skill-card__duration-hint"></span>
+                </div>
+            </div>
+            <div class="skill-card__actions">
+                <button
+                    type="button"
+                    class="btn btn-skill skill-card__button"
+                    data-skill-button
+                    aria-pressed="false"
+                >
+                    <span class="skill-card__button-label">발동</span>
+                </button>
+                <p class="skill-card__status" aria-live="polite"></p>
+            </div>
+        </li>
+    </template>
 
     <template id="heroIconTemplate">
         <li class="hero-icon" data-recruited="false" data-rarity="common">

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -1,0 +1,36 @@
+export const SKILL_EFFECT_TYPES = {
+    DPS_MULTIPLIER: 'dpsMultiplier',
+    BOSS_TIMER_FREEZE: 'bossTimerFreeze',
+    INSTANT_GOLD: 'instantGold',
+};
+
+export const SKILLS = [
+    {
+        id: 'frenzy',
+        name: '아로나의 전술 지원',
+        description: '샬레의 지원 네트워크로 잠시 총 지원 화력을 대폭 끌어올립니다.',
+        cooldown: 60000,
+        duration: 15000,
+        effectType: SKILL_EFFECT_TYPES.DPS_MULTIPLIER,
+        effectValue: 2,
+    },
+    {
+        id: 'timeFreeze',
+        name: '시간 정지 작전',
+        description: '보스 제한시간을 잠시 정지시켜 안정적인 전술 수행을 돕습니다.',
+        cooldown: 90000,
+        duration: 10000,
+        effectType: SKILL_EFFECT_TYPES.BOSS_TIMER_FREEZE,
+    },
+    {
+        id: 'emergencyFunding',
+        name: '비상 보급 요청',
+        description: '현재 지원 화력을 바탕으로 추가 작전 자금을 즉시 확보합니다.',
+        cooldown: 45000,
+        duration: 0,
+        effectType: SKILL_EFFECT_TYPES.INSTANT_GOLD,
+        effectValue: 8,
+    },
+];
+
+export const SKILL_MAP = new Map(SKILLS.map((skill) => [skill.id, skill]));

--- a/styles.css
+++ b/styles.css
@@ -613,6 +613,43 @@ h1,
     width: 100%;
 }
 
+.skill-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.skill-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--subtext-color);
+}
+
+.skill-card__status {
+    font-size: 0.85rem;
+    color: var(--subtext-color);
+}
+
+.skill-card__button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.skill-card__button[aria-pressed='true'] {
+    box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.4);
+}
+
+.skill-card__button[data-skill-state='cooldown'],
+.skill-card__button[data-skill-state='locked'] {
+    opacity: 0.8;
+}
+
 .upgrade-card .btn {
     align-self: flex-start;
 }


### PR DESCRIPTION
## Summary
- add centralized skill definitions including metadata and effect typings
- refactor GameState to manage skill cooldowns/effects and hook into boss timer and DPS routines
- rebuild skills UI to render from data, handle activation, and show accessible cooldown feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb93a2c0a083319cada7c0e8fcbf12