### PR TITLE
Add skill leveling system with upgrade UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@
                                 <dd class="overview-stat__value"><span id="upgradeMaterials">0</span></dd>
                             </div>
                             <div class="overview-stat">
+                                <dt class="overview-stat__label">스킬 모듈</dt>
+                                <dd class="overview-stat__value"><span id="skillModules">0</span></dd>
+                            </div>
+                            <div class="overview-stat">
                                 <dt class="overview-stat__label">모집권</dt>
                                 <dd class="overview-stat__value"><span id="gachaTokensHeader">0</span></dd>
                             </div>
@@ -633,6 +637,11 @@
                 <div class="skill-card__meta">
                     <span class="skill-card__cooldown-hint"></span>
                     <span class="skill-card__duration-hint"></span>
+                    <span class="skill-card__effect-hint"></span>
+                </div>
+                <div class="skill-card__level-info">
+                    <span class="skill-card__level"></span>
+                    <span class="skill-card__next-hint"></span>
                 </div>
             </div>
             <div class="skill-card__actions">
@@ -644,6 +653,16 @@
                 >
                     <span class="skill-card__button-label">발동</span>
                 </button>
+                <div class="skill-card__upgrade">
+                    <button
+                        type="button"
+                        class="btn btn-ghost skill-card__upgrade-button"
+                        data-skill-upgrade
+                    >
+                        강화
+                    </button>
+                    <span class="skill-card__upgrade-cost"></span>
+                </div>
                 <p class="skill-card__status" aria-live="polite"></p>
             </div>
         </li>

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -34,3 +34,168 @@ export const SKILLS = [
 ];
 
 export const SKILL_MAP = new Map(SKILLS.map((skill) => [skill.id, skill]));
+
+export const DEFAULT_SKILL_LEVEL = 1;
+
+const DEFAULT_SKILL_LEVEL_CONFIG = {
+    maxLevel: DEFAULT_SKILL_LEVEL,
+    levels: [
+        {
+            level: DEFAULT_SKILL_LEVEL,
+            effectMultiplier: 1,
+            durationMultiplier: 1,
+            cooldownMultiplier: 1,
+            upgradeCost: null,
+        },
+    ],
+};
+
+export const SKILL_LEVEL_CONFIG = {
+    frenzy: {
+        maxLevel: 5,
+        levels: [
+            {
+                level: 1,
+                effectMultiplier: 1,
+                durationMultiplier: 1,
+                cooldownMultiplier: 1,
+                upgradeCost: 20,
+            },
+            {
+                level: 2,
+                effectMultiplier: 1.25,
+                durationMultiplier: 1.15,
+                cooldownMultiplier: 0.95,
+                upgradeCost: 40,
+            },
+            {
+                level: 3,
+                effectMultiplier: 1.5,
+                durationMultiplier: 1.3,
+                cooldownMultiplier: 0.9,
+                upgradeCost: 80,
+            },
+            {
+                level: 4,
+                effectMultiplier: 1.75,
+                durationMultiplier: 1.45,
+                cooldownMultiplier: 0.85,
+                upgradeCost: 160,
+            },
+            {
+                level: 5,
+                effectMultiplier: 2,
+                durationMultiplier: 1.6,
+                cooldownMultiplier: 0.8,
+                upgradeCost: null,
+            },
+        ],
+    },
+    timeFreeze: {
+        maxLevel: 5,
+        levels: [
+            {
+                level: 1,
+                effectMultiplier: 1,
+                durationMultiplier: 1,
+                cooldownMultiplier: 1,
+                upgradeCost: 30,
+            },
+            {
+                level: 2,
+                effectMultiplier: 1.1,
+                durationMultiplier: 1.2,
+                cooldownMultiplier: 0.95,
+                upgradeCost: 60,
+            },
+            {
+                level: 3,
+                effectMultiplier: 1.2,
+                durationMultiplier: 1.4,
+                cooldownMultiplier: 0.9,
+                upgradeCost: 120,
+            },
+            {
+                level: 4,
+                effectMultiplier: 1.3,
+                durationMultiplier: 1.6,
+                cooldownMultiplier: 0.85,
+                upgradeCost: 240,
+            },
+            {
+                level: 5,
+                effectMultiplier: 1.4,
+                durationMultiplier: 1.8,
+                cooldownMultiplier: 0.8,
+                upgradeCost: null,
+            },
+        ],
+    },
+    emergencyFunding: {
+        maxLevel: 5,
+        levels: [
+            {
+                level: 1,
+                effectMultiplier: 1,
+                durationMultiplier: 1,
+                cooldownMultiplier: 1,
+                upgradeCost: 15,
+            },
+            {
+                level: 2,
+                effectMultiplier: 1.5,
+                durationMultiplier: 1,
+                cooldownMultiplier: 0.95,
+                upgradeCost: 30,
+            },
+            {
+                level: 3,
+                effectMultiplier: 2,
+                durationMultiplier: 1,
+                cooldownMultiplier: 0.9,
+                upgradeCost: 60,
+            },
+            {
+                level: 4,
+                effectMultiplier: 2.5,
+                durationMultiplier: 1,
+                cooldownMultiplier: 0.85,
+                upgradeCost: 120,
+            },
+            {
+                level: 5,
+                effectMultiplier: 3,
+                durationMultiplier: 1,
+                cooldownMultiplier: 0.8,
+                upgradeCost: null,
+            },
+        ],
+    },
+};
+
+export const SKILL_LEVEL_MAP = new Map(Object.entries(SKILL_LEVEL_CONFIG));
+
+export const getSkillLevelConfig = (skillId) => SKILL_LEVEL_MAP.get(skillId) ?? DEFAULT_SKILL_LEVEL_CONFIG;
+
+export const getSkillLevelDefinition = (skillId, level = DEFAULT_SKILL_LEVEL) => {
+    const config = getSkillLevelConfig(skillId);
+    const levels = Array.isArray(config.levels) && config.levels.length > 0 ? config.levels : DEFAULT_SKILL_LEVEL_CONFIG.levels;
+    const clamped = Math.max(DEFAULT_SKILL_LEVEL, Math.min(config.maxLevel ?? DEFAULT_SKILL_LEVEL, Math.floor(level)));
+    return (
+        levels.find((entry) => Number(entry.level) === clamped) ??
+        levels[Math.min(levels.length - 1, clamped - DEFAULT_SKILL_LEVEL)] ??
+        DEFAULT_SKILL_LEVEL_CONFIG.levels[0]
+    );
+};
+
+export const getSkillUpgradeCost = (skillId, level = DEFAULT_SKILL_LEVEL) => {
+    const config = getSkillLevelConfig(skillId);
+    const clampedLevel = Math.max(DEFAULT_SKILL_LEVEL, Math.min(config.maxLevel ?? DEFAULT_SKILL_LEVEL, Math.floor(level)));
+    if (clampedLevel >= (config.maxLevel ?? DEFAULT_SKILL_LEVEL)) {
+        return null;
+    }
+    const definition = getSkillLevelDefinition(skillId, clampedLevel);
+    if (!definition) return null;
+    const rawCost = Number(definition.upgradeCost ?? 0);
+    return Number.isFinite(rawCost) ? Math.max(0, Math.floor(rawCost)) : null;
+};


### PR DESCRIPTION
## Summary
- add level configuration tables for each skill including multipliers and upgrade costs
- extend the game state to track skill levels, skill-module resources, and apply leveled cooldown/effect calculations
- update the UI to show current and next skill effects with an upgrade workflow that consumes saved state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbab4e37808331a69bb377c13ed016