### PR TITLE
Fix overlapping rebirth skill tree layout

### DIFF
--- a/src/ui/gameUI.js
+++ b/src/ui/gameUI.js
@@ -215,6 +215,8 @@ export class GameUI {
         this.rebirthPreviewNodeId = null;
         this.rebirthResizeObserver = null;
         this.rebirthResizeHandler = null;
+        this.rebirthScrollHandler = null;
+        this.rebirthScrollContainer = UI.rebirthTree ?? null;
         this.missionElements = new Map();
         this.missionGroupElements = new Map();
         this.missionGroupMissions = new Map();
@@ -2108,12 +2110,20 @@ export class GameUI {
         const verticalStep = rowCount > 0 ? 100 / rowCount : 100;
         const horizontalStep = columnCount > 0 ? 100 / columnCount : 100;
         const dynamicHeight = Math.max(320, rowCount * 160);
+        const containerWidth = UI.rebirthTree?.clientWidth ?? 0;
+        const estimatedWidth = columnCount > 0 ? columnCount * 220 : 0;
+        const dynamicWidth = Math.max(360, containerWidth, estimatedWidth);
 
         if (UI.rebirthTree) {
             UI.rebirthTree.style.setProperty('--rebirth-tree-min-height', `${dynamicHeight}px`);
+            UI.rebirthTree.style.setProperty('--rebirth-tree-content-width', `${dynamicWidth}px`);
         }
         UI.rebirthTreeNodes.style.minHeight = `${dynamicHeight}px`;
+        UI.rebirthTreeNodes.style.minWidth = `${dynamicWidth}px`;
+        UI.rebirthTreeNodes.style.width = `${dynamicWidth}px`;
         UI.rebirthTreeConnections.style.minHeight = `${dynamicHeight}px`;
+        UI.rebirthTreeConnections.style.minWidth = `${dynamicWidth}px`;
+        UI.rebirthTreeConnections.style.width = `${dynamicWidth}px`;
 
         nodes.forEach((node) => {
             const wrapper = document.createElement('button');
@@ -2646,6 +2656,13 @@ export class GameUI {
         if (!UI.rebirthTreeNodes) {
             return;
         }
+        if (UI.rebirthTree && !this.rebirthScrollHandler) {
+            this.rebirthScrollContainer = UI.rebirthTree;
+            this.rebirthScrollHandler = () => this.updateRebirthConnections();
+            this.rebirthScrollContainer.addEventListener('scroll', this.rebirthScrollHandler, {
+                passive: true,
+            });
+        }
         if (typeof ResizeObserver !== 'undefined') {
             try {
                 this.rebirthResizeObserver = new ResizeObserver(() => this.updateRebirthConnections());
@@ -2667,6 +2684,13 @@ export class GameUI {
         if (this.rebirthResizeHandler) {
             window.removeEventListener('resize', this.rebirthResizeHandler);
             this.rebirthResizeHandler = null;
+        }
+        if (this.rebirthScrollContainer && this.rebirthScrollHandler) {
+            this.rebirthScrollContainer.removeEventListener('scroll', this.rebirthScrollHandler);
+            this.rebirthScrollHandler = null;
+        }
+        if (!UI.rebirthTree) {
+            this.rebirthScrollContainer = null;
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -1037,19 +1037,22 @@ h1,
     padding: 1.5rem;
     min-height: var(--rebirth-tree-min-height, 320px);
     box-shadow: inset 0 0 30px rgba(15, 23, 42, 0.35);
+    overflow: auto;
 }
 
 .rebirth-tree__connections {
     position: absolute;
     inset: 0;
-    width: 100%;
+    width: var(--rebirth-tree-content-width, 100%);
+    min-width: var(--rebirth-tree-content-width, 100%);
     height: 100%;
     pointer-events: none;
 }
 
 .rebirth-tree__nodes {
     position: relative;
-    width: 100%;
+    width: var(--rebirth-tree-content-width, 100%);
+    min-width: var(--rebirth-tree-content-width, 100%);
     height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- ensure the rebirth tree container can scroll and expand to the calculated width so nodes no longer overlap
- compute a dynamic content width for the rebirth tree nodes and connections when rendering and keep the connector lines in sync while scrolling

## Testing
- not run (project does not include automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cbeec7a2448331837ca07e6d950611