### PR TITLE
Adjust daily gacha mission balance

### DIFF
--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -37,10 +37,10 @@ const BASE_MISSION_GROUPS = [
             {
                 id: 'gacha_30',
                 name: '모집 전문가',
-                description: '학생 모집을 30회 진행하세요.',
+                description: '학생 모집을 20회 진행하세요.',
                 trigger: 'gachaRoll',
-                goal: 30,
-                reward: { type: 'gold', amount: 1200 },
+                goal: 20,
+                reward: { type: 'gachaTokens', amount: 2 },
             },
             {
                 id: 'salvage_20',


### PR DESCRIPTION
## Summary
- reduce the daily gacha mission requirement to 20 rolls
- switch the mission reward to gacha tokens and update the description

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccd5224cb48331b41a22239df5532b