### PR TITLE
Fix rebirth point UI refresh after earning points

### DIFF
--- a/src/ui/gameUI.js
+++ b/src/ui/gameUI.js
@@ -3747,6 +3747,9 @@ export class GameUI {
         this.updateMissionUI();
         this.updateStats();
         this.updateGachaUI();
+        if (result.rewardResult?.type === 'rebirthPoints') {
+            this.updateRebirthUI();
+        }
         saveGame(this.state);
     }
 
@@ -3861,6 +3864,7 @@ export class GameUI {
         );
         this.renderHeroes();
         this.updateUI();
+        this.updateRebirthUI();
         this.handleMissionProgress('rebirth', 1);
         saveGame(this.state);
     }


### PR DESCRIPTION
## Summary
- refresh the rebirth UI after completing a rebirth so newly earned points and cores become usable immediately
- refresh the rebirth UI when claiming mission rewards that grant rebirth points

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3821113cc8331a6182205fb745572